### PR TITLE
Fix request status code check

### DIFF
--- a/src/GithubIssues.py
+++ b/src/GithubIssues.py
@@ -304,7 +304,7 @@ class GithubIssuesAPI:
         print(f"{self.__utils.stacktrace()} INFO remaining API call allowance = {self.__get_remaining_calls()}.")
 
         # check for valid response
-        if not self.__response.headers['Status'].startswith("200 "):
+        if not self.__response.ok:
             self.__status = 201
             self.__process_response_error()
             exit()


### PR DESCRIPTION
Uses `requests`' status code check instead of a custom one.  This is causing an issue as the key `status` isn't found in the headers 

```
Traceback (most recent call last):
  File ".../RepoDash/src/RepoDash.py", line 54, in <module>
    ga.get_next_page(args)
  File ".../RepoDash/src/GithubIssues.py", line 307, in get_next_page
    if not self.__response.headers['Status'].startswith("200 "):
  File ".../python3.9/site-packages/requests/structures.py", line 54, in __getitem__
    return self._store[key.lower()][1]
KeyError: 'status'
```

Replacing this check with the one build into `requests` is more robust and fixes the issue